### PR TITLE
Add GAN model support to wxbtool

### DIFF
--- a/tests/models/fast_gan.py
+++ b/tests/models/fast_gan.py
@@ -68,9 +68,9 @@ class Mdl(Spec):
         cnst = self.get_augmented_constant(input)
         input = th.cat((input, cnst, noise), dim=1)
 
-        output = self.mlp(input)
+        output = self.mlp(input).view(batch_size, self.setting.pred_span, 32, 64)
 
-        return {"t2m": output.view(batch_size, self.setting.pred_span, 32, 64)}
+        return {"t2m": output, "data": output}
 
 
 class Dsc(Spec):
@@ -106,9 +106,9 @@ class Dsc(Spec):
         cnst = self.get_augmented_constant(input)
         input = th.cat((input, cnst, target), dim=1)
 
-        output = self.mlp(input)
+        output = self.mlp(input).view(batch_size, self.setting.pred_span, 32, 64)
 
-        return {"t2m": output.view(batch_size, self.setting.pred_span, 32, 64)}
+        return {"t2m": output, "data": output}
 
 
 generator = Mdl(setting)

--- a/tests/models/fast_gan.py
+++ b/tests/models/fast_gan.py
@@ -1,0 +1,115 @@
+"""
+    Test model in wxbtool package
+"""
+
+import numpy as np
+import torch as th
+
+from leibniz.nn.net import SimpleCNN2d
+from torch.utils.data import Dataset
+
+from tests.spec.spec import Setting10d, Spec
+from wxbtool.data.variables import vars3d
+
+
+setting = Setting10d()
+
+
+class TestDataset(Dataset):
+    def __len__(self):
+        return 60
+
+    def __getitem__(self, item):
+        inputs, targets = {}, {}
+        for var in setting.vars:
+            if var in vars3d:
+                inputs.update(
+                    {var: np.ones((1, setting.input_span, setting.height, 32, 64))}
+                )
+                targets.update(
+                    {var: np.ones((1, setting.pred_span, setting.height, 32, 64))}
+                )
+            else:
+                inputs.update({var: np.ones((1, setting.input_span, 32, 64))})
+                targets.update({var: np.ones((1, setting.pred_span, 32, 64))})
+        return inputs, targets
+
+
+class Mdl(Spec):
+    def __init__(self, setting):
+        super().__init__(setting)
+        self.name = "fast"
+        self.mlp = SimpleCNN2d(
+            self.setting.input_span * len(self.setting.vars_in)
+            + self.constant_size
+            + 2
+            + 1,
+            self.setting.pred_span * len(self.setting.vars_out),
+        )
+
+    def load_dataset(self, phase, mode, **kwargs):
+        self.phase = phase
+        self.mode = mode
+
+        self.dataset_train = TestDataset()
+        self.dataset_eval = TestDataset()
+        self.dataset_test = TestDataset()
+
+        self.train_size = len(self.dataset_train)
+        self.eval_size = len(self.dataset_eval)
+        self.test_size = len(self.dataset_test)
+
+    def forward(self, **kwargs):
+        batch_size = kwargs["2m_temperature"].size()[0]
+        self.update_da_status(batch_size)
+
+        _, input = self.get_inputs(**kwargs)
+        noise = kwargs['noise']
+        cnst = self.get_augmented_constant(input)
+        input = th.cat((input, cnst, noise), dim=1)
+
+        output = self.mlp(input)
+
+        return {"t2m": output.view(batch_size, self.setting.pred_span, 32, 64)}
+
+
+class Dsc(Spec):
+    def __init__(self, setting):
+        super().__init__(setting)
+        self.name = "fast"
+        self.mlp = SimpleCNN2d(
+            self.setting.input_span * len(self.setting.vars_in)
+            + self.constant_size
+            + 2
+            + 1,
+            self.setting.pred_span * len(self.setting.vars_out),
+        )
+
+    def load_dataset(self, phase, mode, **kwargs):
+        self.phase = phase
+        self.mode = mode
+
+        self.dataset_train = TestDataset()
+        self.dataset_eval = TestDataset()
+        self.dataset_test = TestDataset()
+
+        self.train_size = len(self.dataset_train)
+        self.eval_size = len(self.dataset_eval)
+        self.test_size = len(self.dataset_test)
+
+    def forward(self, **kwargs):
+        batch_size = kwargs["2m_temperature"].size()[0]
+        self.update_da_status(batch_size)
+
+        _, input = self.get_inputs(**kwargs)
+        target = kwargs['target']
+        cnst = self.get_augmented_constant(input)
+        input = th.cat((input, cnst, target), dim=1)
+
+        output = self.mlp(input)
+
+        return {"t2m": output.view(batch_size, self.setting.pred_span, 32, 64)}
+
+
+generator = Mdl(setting)
+discriminator = Dsc(setting)

--- a/tests/models/fast_gan.py
+++ b/tests/models/fast_gan.py
@@ -38,7 +38,7 @@ class TestDataset(Dataset):
 class Mdl(Spec):
     def __init__(self, setting):
         super().__init__(setting)
-        self.name = "fast"
+        self.name = "fastg"
         self.mlp = SimpleCNN2d(
             self.setting.input_span * len(self.setting.vars_in)
             + self.constant_size
@@ -76,7 +76,7 @@ class Mdl(Spec):
 class Dsc(Spec):
     def __init__(self, setting):
         super().__init__(setting)
-        self.name = "fast"
+        self.name = "fastd"
         self.mlp = SimpleCNN2d(
             self.setting.input_span * len(self.setting.vars_in)
             + self.constant_size

--- a/tests/spec/spec.py
+++ b/tests/spec/spec.py
@@ -96,16 +96,19 @@ class Spec(Base2d):
             vdic[nm] = d
             vlst.append(d)
 
-        return vdic, th.cat(vlst, dim=1)
+        data = th.cat(vlst, dim=1)
+        vdic['data'] = data
+
+        return vdic, data
 
     def get_targets(self, **kwargs):
         t2m = kwargs["2m_temperature"].view(-1, self.setting.pred_span, 32, 64)
         t2m = self.augment_data(t2m)
-        return {"t2m": t2m}, t2m
+        return {"t2m": t2m, "data": t2m}, t2m
 
     def get_results(self, **kwargs):
         t2m = denorm_t2m(kwargs["t2m"])
-        return {"t2m": t2m}, t2m
+        return {"t2m": t2m, "data": t2m}, t2m
 
     def forward(self, **kwargs):
         raise NotImplementedError("Spec is abstract and can not be initialized")

--- a/tests/spec/spec.py
+++ b/tests/spec/spec.py
@@ -88,9 +88,9 @@ class Spec(Base2d):
             if v in vars3d:
                 d = kwargs[v].view(
                     -1, self.setting.input_span, self.setting.height, 32, 64
-                )[:, :, self.setting.levels.index(lvl)]
+                )[:, :, self.setting.levels.index(lvl)].float()
             else:
-                d = kwargs[v].view(-1, self.setting.input_span, 32, 64)
+                d = kwargs[v].view(-1, self.setting.input_span, 32, 64).float()
             d = normalizors[nm](d)
             d = self.augment_data(d)
             vdic[nm] = d

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -90,6 +90,6 @@ class TestTrain(unittest.TestCase):
     def test_train10d_gan(self):
         import wxbtool.wxb as wxb
 
-        testargs = ["wxb", "train", "-m", "models.fast_gan", "-b", "10", "-n", "2", "-g", "true"]
+        testargs = ["wxb", "train", "-m", "models.fast_gan", "-b", "10", "-n", "2", "-G", "true"]
         with patch.object(sys, "argv", testargs):
             wxb.main()

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -83,3 +83,13 @@ class TestTrain(unittest.TestCase):
         testargs = ["wxb", "train", "-m", "models.fast_10d", "-b", "10", "-n", "2"]
         with patch.object(sys, "argv", testargs):
             wxb.main()
+
+    @mock.patch.dict(
+        os.environ, {"WXBHOME": str(pathlib.Path(__file__).parent.absolute())}
+    )
+    def test_train10d_gan(self):
+        import wxbtool.wxb as wxb
+
+        testargs = ["wxb", "train", "-m", "models.fast_gan", "-b", "10", "-n", "2", "-g", "true"]
+        with patch.object(sys, "argv", testargs):
+            wxb.main()

--- a/wxbtool/nn/lightning.py
+++ b/wxbtool/nn/lightning.py
@@ -161,3 +161,160 @@ class LightningModel(ltn.LightningModule):
             num_workers=self.opt.n_cpu,
             shuffle=False,
         )
+
+
+class GANModel(ltn.LightningModule):
+    def __init__(self, model, opt=None):
+        super(GANModel, self).__init__()
+        self.model = model
+        self.learning_rate = 1e-3
+
+        self.counter = 0
+        self.labeled_loss = 0
+        self.labeled_rmse = 0
+
+        self.opt = opt
+
+    def configure_optimizers(self):
+        optimizer = th.optim.Adam(self.parameters(), lr=self.learning_rate)
+        scheduler = th.optim.lr_scheduler.CosineAnnealingLR(optimizer, 53)
+        return [optimizer], [scheduler]
+
+    def loss_fn(self, input, result, target):
+        return self.model.lossfun(input, result, target)
+
+    def compute_rmse(self, targets, results):
+        _, tgt = self.model.get_targets(**targets)
+        _, rst = self.model.get_results(**results)
+        tgt = (
+            tgt.detach().cpu().numpy().reshape(-1, self.model.setting.pred_span, 32, 64)
+        )
+        rst = (
+            rst.detach().cpu().numpy().reshape(-1, self.model.setting.pred_span, 32, 64)
+        )
+        rmse = np.sqrt(np.mean(self.model.weight.cpu().numpy() * (rst - tgt) ** 2))
+        return rmse
+
+    def forward(self, **inputs):
+        return self.model(**inputs)
+
+    def plot(self, inputs, results, targets):
+        vars_in, _ = self.model.get_inputs(**inputs)
+        for bas, var in enumerate(self.model.setting.vars_in):
+            for ix in range(self.model.setting.input_span):
+                img = vars_in[var][0, ix].detach().cpu().numpy().reshape(32, 64)
+                plot(var, open("%s_inp_%d.png" % (var, ix), mode="wb"), img)
+
+        vars_fc, _ = self.model.get_results(**results)
+        vars_tg, _ = self.model.get_targets(**targets)
+        for bas, var in enumerate(self.model.setting.vars_out):
+            for ix in range(self.model.setting.pred_span):
+                fcst = vars_fc[var][0, ix].detach().cpu().numpy().reshape(32, 64)
+                tgrt = vars_tg[var][0, ix].detach().cpu().numpy().reshape(32, 64)
+                plot(var, open("%s_fcs_%d.png" % (var, ix), mode="wb"), fcst)
+                plot(var, open("%s_tgt_%d.png" % (var, ix), mode="wb"), tgrt)
+
+    def training_step(self, batch, batch_idx):
+        inputs, targets = batch
+        inputs = {v: inputs[v].float() for v in self.model.setting.vars}
+        targets = {v: targets[v].float() for v in self.model.setting.vars}
+        results = self.forward(**inputs)
+
+        loss = self.loss_fn(inputs, results, targets)
+
+        self.log("train_loss", loss, on_step=True, on_epoch=True, prog_bar=True)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        inputs, targets = batch
+        inputs = {v: inputs[v].float() for v in self.model.setting.vars}
+        targets = {v: targets[v].float() for v in self.model.setting.vars}
+        results = self.forward(**inputs)
+        loss = self.loss_fn(inputs, results, targets)
+        rmse = self.compute_rmse(targets, results)
+
+        self.log("val_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.log("val_rmse", rmse, on_step=False, on_epoch=True, prog_bar=True)
+
+        batch_len = inputs[self.model.setting.vars[0]].shape[0]
+        self.labeled_loss += loss.item() * batch_len
+        self.labeled_rmse += rmse * batch_len
+        self.counter += batch_len
+
+        self.plot(inputs, results, targets)
+
+    def test_step(self, batch, batch_idx):
+        inputs, targets = batch
+        inputs = {v: inputs[v].float() for v in self.model.setting.vars}
+        targets = {v: targets[v].float() for v in self.model.setting.vars}
+        results = self.forward(**inputs)
+        loss = self.loss_fn(inputs, results, targets)
+        rmse = self.compute_rmse(targets, results)
+
+        self.log("test_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.log("test_rmse", rmse, on_step=False, on_epoch=True, prog_bar=True)
+
+        self.plot(inputs, results, targets)
+
+    def on_save_checkpoint(self, checkpoint) -> None:
+        import glob
+        import os
+
+        rmse = self.labeled_rmse / self.counter
+        loss = self.labeled_loss / self.counter
+        record = "%2.5f-%03d-%1.5f.ckpt" % (rmse, checkpoint["epoch"], loss)
+        mname = self.model.name
+        fname = f"trains/{mname}/best-{record}"
+        os.makedirs(
+            f"trains/{mname}", exist_ok=True
+        )
+        with open(fname, "bw") as f:
+            th.save(checkpoint, f)
+        for ix, ckpt in enumerate(sorted(glob.glob(f"trains/{mname}/best-*.ckpt"), reverse=False)):
+            if ix > 5:
+                os.unlink(ckpt)
+
+        self.counter = 0
+        self.labeled_loss = 0
+        self.labeled_rmse = 0
+
+        print()
+
+    def train_dataloader(self):
+        if self.model.dataset_train is None:
+            if self.opt.data != "":
+                self.model.load_dataset("train", "client", url=self.opt.data)
+            else:
+                self.model.load_dataset("train", "server")
+        return DataLoader(
+            self.model.dataset_train,
+            batch_size=self.opt.batch_size,
+            num_workers=self.opt.n_cpu,
+            shuffle=True,
+        )
+
+    def val_dataloader(self):
+        if self.model.dataset_eval is None:
+            if self.opt.data != "":
+                self.model.load_dataset("train", "client", url=self.opt.data)
+            else:
+                self.model.load_dataset("train", "server")
+        return DataLoader(
+            self.model.dataset_eval,
+            batch_size=self.opt.batch_size,
+            num_workers=self.opt.n_cpu,
+            shuffle=False,
+        )
+
+    def test_dataloader(self):
+        if self.model.dataset_test is None:
+            if self.opt.data != "":
+                self.model.load_dataset("train", "client", url=self.opt.data)
+            else:
+                self.model.load_dataset("train", "server")
+        return DataLoader(
+            self.model.dataset_test,
+            batch_size=self.opt.batch_size,
+            num_workers=self.opt.n_cpu,
+            shuffle=False,
+        )

--- a/wxbtool/nn/lightning.py
+++ b/wxbtool/nn/lightning.py
@@ -57,7 +57,7 @@ class LightningModel(ltn.LightningModule):
                 plot(var, open("%s_fcs_%d.png" % (var, ix), mode="wb"), fcst)
                 plot(var, open("%s_tgt_%d.png" % (var, ix), mode="wb"), tgrt)
 
-    def training_step(self, batch, batch_idx):
+    def training_step(self, batch, batch_idx, optimizer_idx):
         inputs, targets = batch
         inputs = {v: inputs[v].float() for v in self.model.setting.vars}
         targets = {v: targets[v].float() for v in self.model.setting.vars}
@@ -163,11 +163,12 @@ class LightningModel(ltn.LightningModule):
         )
 
 
-class GANModel(ltn.LightningModule):
-    def __init__(self, model, opt=None):
+class GANModel(LightningModel):
+    def __init__(self, generator, discriminator, opt=None):
         super(GANModel, self).__init__()
-        self.model = model
-        self.learning_rate = 1e-3
+        self.generator = generator
+        self.discriminator = discriminator
+        self.learning_rate = 1e-4  # Adjusted for GANs
 
         self.counter = 0
         self.labeled_loss = 0
@@ -176,145 +177,73 @@ class GANModel(ltn.LightningModule):
         self.opt = opt
 
     def configure_optimizers(self):
-        optimizer = th.optim.Adam(self.parameters(), lr=self.learning_rate)
-        scheduler = th.optim.lr_scheduler.CosineAnnealingLR(optimizer, 53)
-        return [optimizer], [scheduler]
+        # Separate optimizers for generator and discriminator
+        g_optimizer = th.optim.Adam(self.generator.parameters(), lr=2 * self.learning_rate)
+        d_optimizer = th.optim.Adam(self.discriminator.parameters(), lr=self.learning_rate)
+        return [g_optimizer, d_optimizer]
+
+    def generator_loss(self, fake_judgement):
+        # Loss for generator (we want the discriminator to predict all generated images as real)
+        return th.nn.functional.binary_cross_entropy_with_logits(fake_judgement, th.ones_like(fake_judgement))
+
+    def discriminator_loss(self, real_judgement, fake_judgement):
+        # Loss for discriminator (real images should be classified as real, fake images as fake)
+        real_loss = th.nn.functional.binary_cross_entropy_with_logits(real_judgement, th.ones_like(real_judgement))
+        fake_loss = th.nn.functional.binary_cross_entropy_with_logits(fake_judgement, th.zeros_like(fake_judgement))
+        return (real_loss + fake_loss) / 2
 
     def loss_fn(self, input, result, target):
         return self.model.lossfun(input, result, target)
 
-    def compute_rmse(self, targets, results):
-        _, tgt = self.model.get_targets(**targets)
-        _, rst = self.model.get_results(**results)
-        tgt = (
-            tgt.detach().cpu().numpy().reshape(-1, self.model.setting.pred_span, 32, 64)
-        )
-        rst = (
-            rst.detach().cpu().numpy().reshape(-1, self.model.setting.pred_span, 32, 64)
-        )
-        rmse = np.sqrt(np.mean(self.model.weight.cpu().numpy() * (rst - tgt) ** 2))
-        return rmse
-
     def forward(self, **inputs):
-        return self.model(**inputs)
+        return self.generator(**inputs)
 
-    def plot(self, inputs, results, targets):
-        vars_in, _ = self.model.get_inputs(**inputs)
-        for bas, var in enumerate(self.model.setting.vars_in):
-            for ix in range(self.model.setting.input_span):
-                img = vars_in[var][0, ix].detach().cpu().numpy().reshape(32, 64)
-                plot(var, open("%s_inp_%d.png" % (var, ix), mode="wb"), img)
-
-        vars_fc, _ = self.model.get_results(**results)
-        vars_tg, _ = self.model.get_targets(**targets)
-        for bas, var in enumerate(self.model.setting.vars_out):
-            for ix in range(self.model.setting.pred_span):
-                fcst = vars_fc[var][0, ix].detach().cpu().numpy().reshape(32, 64)
-                tgrt = vars_tg[var][0, ix].detach().cpu().numpy().reshape(32, 64)
-                plot(var, open("%s_fcs_%d.png" % (var, ix), mode="wb"), fcst)
-                plot(var, open("%s_tgt_%d.png" % (var, ix), mode="wb"), tgrt)
-
-    def training_step(self, batch, batch_idx):
+    def training_step(self, batch, batch_idx, optimizer_idx):
         inputs, targets = batch
         inputs = {v: inputs[v].float() for v in self.model.setting.vars}
         targets = {v: targets[v].float() for v in self.model.setting.vars}
-        results = self.forward(**inputs)
+        inputs['noise'] = th.randn_like(inputs['data'][:, :1, :, :])
 
-        loss = self.loss_fn(inputs, results, targets)
+        if optimizer_idx == 0:
+            forecast = self.generator(**inputs)
+            judgement = self.discriminator(**inputs, target=forecast)
+            forecast_loss = self.loss_fn(inputs, forecast, targets)
+            generate_loss = self.generator_loss(judgement)
+            total_loss = forecast_loss + generate_loss
+            self.log("total", total_loss, on_step=True, on_epoch=True, prog_bar=True)
+            self.log("forecast", forecast_loss, on_step=True, on_epoch=True, prog_bar=True)
+            return total_loss
 
-        self.log("train_loss", loss, on_step=True, on_epoch=True, prog_bar=True)
-        return loss
+        elif optimizer_idx == 1:
+            forecast = self.generator(**inputs).detach()  # Detach to avoid generator gradient updates
+            real_judgement = self.discriminator(**inputs, target=targets['data'])
+            fake_judgement = self.discriminator(**inputs, target=forecast)
+            judgement_loss = self.discriminator_loss(real_judgement, fake_judgement)
+            self.log("judgement", judgement_loss, on_step=True, on_epoch=True, prog_bar=True)
+            return judgement_loss
 
     def validation_step(self, batch, batch_idx):
         inputs, targets = batch
         inputs = {v: inputs[v].float() for v in self.model.setting.vars}
         targets = {v: targets[v].float() for v in self.model.setting.vars}
-        results = self.forward(**inputs)
-        loss = self.loss_fn(inputs, results, targets)
-        rmse = self.compute_rmse(targets, results)
-
-        self.log("val_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
-        self.log("val_rmse", rmse, on_step=False, on_epoch=True, prog_bar=True)
-
-        batch_len = inputs[self.model.setting.vars[0]].shape[0]
-        self.labeled_loss += loss.item() * batch_len
-        self.labeled_rmse += rmse * batch_len
-        self.counter += batch_len
-
-        self.plot(inputs, results, targets)
+        inputs['noise'] = th.randn_like(inputs['data'][:, :1, :, :])
+        forecast = self.generator(**inputs)
+        judgement = self.discriminator(inputs, forecast)
+        forecast_loss = self.loss_fn(inputs, forecast, targets)
+        realness = judgement.mean().item()
+        self.log("realness", realness, on_step=False, on_epoch=True, prog_bar=True)
+        self.log("forecast", forecast_loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.plot(inputs, forecast, targets)
 
     def test_step(self, batch, batch_idx):
         inputs, targets = batch
         inputs = {v: inputs[v].float() for v in self.model.setting.vars}
         targets = {v: targets[v].float() for v in self.model.setting.vars}
-        results = self.forward(**inputs)
-        loss = self.loss_fn(inputs, results, targets)
-        rmse = self.compute_rmse(targets, results)
-
-        self.log("test_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
-        self.log("test_rmse", rmse, on_step=False, on_epoch=True, prog_bar=True)
-
-        self.plot(inputs, results, targets)
-
-    def on_save_checkpoint(self, checkpoint) -> None:
-        import glob
-        import os
-
-        rmse = self.labeled_rmse / self.counter
-        loss = self.labeled_loss / self.counter
-        record = "%2.5f-%03d-%1.5f.ckpt" % (rmse, checkpoint["epoch"], loss)
-        mname = self.model.name
-        fname = f"trains/{mname}/best-{record}"
-        os.makedirs(
-            f"trains/{mname}", exist_ok=True
-        )
-        with open(fname, "bw") as f:
-            th.save(checkpoint, f)
-        for ix, ckpt in enumerate(sorted(glob.glob(f"trains/{mname}/best-*.ckpt"), reverse=False)):
-            if ix > 5:
-                os.unlink(ckpt)
-
-        self.counter = 0
-        self.labeled_loss = 0
-        self.labeled_rmse = 0
-
-        print()
-
-    def train_dataloader(self):
-        if self.model.dataset_train is None:
-            if self.opt.data != "":
-                self.model.load_dataset("train", "client", url=self.opt.data)
-            else:
-                self.model.load_dataset("train", "server")
-        return DataLoader(
-            self.model.dataset_train,
-            batch_size=self.opt.batch_size,
-            num_workers=self.opt.n_cpu,
-            shuffle=True,
-        )
-
-    def val_dataloader(self):
-        if self.model.dataset_eval is None:
-            if self.opt.data != "":
-                self.model.load_dataset("train", "client", url=self.opt.data)
-            else:
-                self.model.load_dataset("train", "server")
-        return DataLoader(
-            self.model.dataset_eval,
-            batch_size=self.opt.batch_size,
-            num_workers=self.opt.n_cpu,
-            shuffle=False,
-        )
-
-    def test_dataloader(self):
-        if self.model.dataset_test is None:
-            if self.opt.data != "":
-                self.model.load_dataset("train", "client", url=self.opt.data)
-            else:
-                self.model.load_dataset("train", "server")
-        return DataLoader(
-            self.model.dataset_test,
-            batch_size=self.opt.batch_size,
-            num_workers=self.opt.n_cpu,
-            shuffle=False,
-        )
+        inputs['noise'] = th.randn_like(inputs['data'][:, :1, :, :])
+        forecast = self.generator(**inputs)
+        judgement = self.discriminator(inputs, forecast)
+        forecast_loss = self.loss_fn(inputs, forecast, targets)
+        realness = judgement.mean().item()
+        self.log("realness", realness, on_step=False, on_epoch=True, prog_bar=True)
+        self.log("forecast", forecast_loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.plot(inputs, forecast, targets)

--- a/wxbtool/nn/lightning.py
+++ b/wxbtool/nn/lightning.py
@@ -165,17 +165,11 @@ class LightningModel(ltn.LightningModule):
 
 class GANModel(LightningModel):
     def __init__(self, generator, discriminator, opt=None):
-        super(GANModel, self).__init__()
+        super(GANModel, self).__init__(generator, opt=opt)
         self.generator = generator
         self.discriminator = discriminator
         self.learning_rate = 1e-4  # Adjusted for GANs
         self.automatic_optimization = False
-
-        self.counter = 0
-        self.labeled_loss = 0
-        self.labeled_rmse = 0
-
-        self.opt = opt
 
     def configure_optimizers(self):
         # Separate optimizers for generator and discriminator

--- a/wxbtool/nn/lightning.py
+++ b/wxbtool/nn/lightning.py
@@ -189,8 +189,8 @@ class GANModel(LightningModel):
 
     def training_step(self, batch, batch_idx):
         inputs, targets = batch
-        inputs = {v: inputs[v].float() for v in self.model.setting.vars}
-        targets = {v: targets[v].float() for v in self.model.setting.vars}
+        inputs = self.get_inputs(**inputs)
+        targets = self.get_targets(**targets)
         inputs['noise'] = th.randn_like(inputs['data'][:, :1, :, :])
 
         g_optimizer, d_optimizer = self.optimizers()

--- a/wxbtool/nn/lightning.py
+++ b/wxbtool/nn/lightning.py
@@ -187,12 +187,6 @@ class GANModel(LightningModel):
         fake_loss = th.nn.functional.binary_cross_entropy_with_logits(fake_judgement, th.zeros_like(fake_judgement))
         return (real_loss + fake_loss) / 2
 
-    def loss_fn(self, input, result, target):
-        return self.model.lossfun(input, result, target)
-
-    def forward(self, **inputs):
-        return self.generator(**inputs)
-
     def training_step(self, batch, batch_idx):
         inputs, targets = batch
         inputs = {v: inputs[v].float() for v in self.model.setting.vars}

--- a/wxbtool/nn/train.py
+++ b/wxbtool/nn/train.py
@@ -6,7 +6,7 @@ import torch as th
 import lightning.pytorch as pl
 
 from lightning.pytorch.callbacks import EarlyStopping
-from wxbtool.nn.lightning import LightningModel
+from wxbtool.nn.lightning import LightningModel, GANModel
 
 
 if th.cuda.is_available():
@@ -24,7 +24,11 @@ def main(context, opt):
         sys.path.insert(0, os.getcwd())
         mdm = importlib.import_module(opt.module, package=None)
 
-        model = LightningModel(mdm.model, opt=opt)
+        if opt.mode == "gan":
+            model = GANModel(mdm.model, opt=opt)
+        else:
+            model = LightningModel(mdm.model, opt=opt)
+
         n_epochs = 1 if opt.test == "true" else opt.n_epochs
         trainer = pl.Trainer(
             accelerator=accelerator,

--- a/wxbtool/nn/train.py
+++ b/wxbtool/nn/train.py
@@ -24,8 +24,8 @@ def main(context, opt):
         sys.path.insert(0, os.getcwd())
         mdm = importlib.import_module(opt.module, package=None)
 
-        if opt.mode == "gan":
-            model = GANModel(mdm.model, opt=opt)
+        if opt.gan == "true":
+            model = GANModel(mdm.generator, mdm.discriminator, opt=opt)
         else:
             model = LightningModel(mdm.model, opt=opt)
 

--- a/wxbtool/wxb.py
+++ b/wxbtool/wxb.py
@@ -102,11 +102,12 @@ def train(parser, context, args):
         help="http url of the dataset server or binding unix socket (unix:/path/to/your.sock)",
     )
     parser.add_argument(
-        "-t", "--test", type=str, default="false", help="setting for test"
+        "-G", "--gan", type=str, default="false", help="training GAN or not, default is false"
     )
     parser.add_argument(
-        "-g", "--gan", type=str, default="false", help="training GAN or not, default is false"
+        "-t", "--test", type=str, default="false", help="setting for test"
     )
+
     opt = parser.parse_args(args)
 
     tnmain(context, opt)

--- a/wxbtool/wxb.py
+++ b/wxbtool/wxb.py
@@ -104,6 +104,9 @@ def train(parser, context, args):
     parser.add_argument(
         "-t", "--test", type=str, default="false", help="setting for test"
     )
+    parser.add_argument(
+        "-mode", "--mode", type=str, default="default", help="training mode (default or gan)"
+    )
     opt = parser.parse_args(args)
 
     tnmain(context, opt)

--- a/wxbtool/wxb.py
+++ b/wxbtool/wxb.py
@@ -105,7 +105,7 @@ def train(parser, context, args):
         "-t", "--test", type=str, default="false", help="setting for test"
     )
     parser.add_argument(
-        "-mode", "--mode", type=str, default="default", help="training mode (default or gan)"
+        "-g", "--gan", type=str, default="false", help="training GAN or not, default is false"
     )
     opt = parser.parse_args(args)
 


### PR DESCRIPTION
Add support for GAN training mode in wxb CLI tool.

* **wxbtool/wxb.py**
  - Add `-mode` option to the `train` subcommand argument parser.
  - Parse the `-mode` argument in the `train` function.
  - Pass the `-mode` argument to the `tnmain` function in the `train` function.

* **wxbtool/nn/train.py**
  - Import `GANModel` from `wxbtool/nn/lightning.py`.
  - Instantiate either `LightningModel` or `GANModel` based on the `mode` argument in the `train` function.

* **wxbtool/nn/lightning.py**
  - Create a new `GANModel` class that inherits from `ltn.LightningModule`.
  - Implement `configure_optimizers`, `loss_fn`, `training_step`, `validation_step`, and `test_step` methods in `GANModel`.
  - Ensure `GANModel` has the same interface as `LightningModel`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mountain/wxbtool/pull/5?shareId=17e5b6d1-7a1f-4a62-8266-3ae359cbb087).