### PR TITLE
Add infer and inferg subcommands to wxb tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Start a testing process for a UNet model following Weyn's solution
 wxb test -m wxbtool.zoo.res5_625.unet.t850d3sm_weyn
 ```
 
+Start an inference process for a UNet model following Weyn's solution
+```bash
+wxb infer -m wxbtool.zoo.res5_625.unet.t850d3sm_weyn -t 2023-01-01T00:00:00 -o output.png
+```
+
+Start a GAN inference process for a UNet model following Weyn's solution
+```bash
+wxb inferg -m wxbtool.zoo.res5_625.unet.t850d3sm_weyn -t 2023-01-01T00:00:00 -s 10 -o output.nc
+```
+
 Start a data set server with unix socket binding
 ```bash
 wxb dserve -m wxbtool.specs.res5_625.t850weyn -s Setting3d -b unix:/tmp/test.sock

--- a/wxbtool/nn/infer.py
+++ b/wxbtool/nn/infer.py
@@ -6,6 +6,7 @@ import xarray as xr
 import numpy as np
 import matplotlib.pyplot as plt
 
+from wxbtool.data.dataset import WxDataset
 from wxbtool.util.plotter import plot
 
 if th.cuda.is_available():

--- a/wxbtool/nn/infer.py
+++ b/wxbtool/nn/infer.py
@@ -1,0 +1,146 @@
+import os
+import sys
+import importlib
+import torch as th
+import xarray as xr
+import numpy as np
+import matplotlib.pyplot as plt
+
+from wxbtool.util.plotter import plot
+
+if th.cuda.is_available():
+    accelerator = "gpu"
+    th.set_float32_matmul_precision("medium")
+elif th.backends.mps.is_available():
+    accelerator = "cpu"
+else:
+    accelerator = "cpu"
+
+
+def main(context, opt):
+    try:
+        os.environ["CUDA_VISIBLE_DEVICES"] = opt.gpu
+        sys.path.insert(0, os.getcwd())
+        mdm = importlib.import_module(opt.module, package=None)
+        model = mdm.model
+
+        # Load the model checkpoint if provided
+        if opt.load:
+            checkpoint = th.load(opt.load)
+            model.load_state_dict(checkpoint['state_dict'])
+
+        # Set the model to evaluation mode
+        model.eval()
+
+        # Load the dataset
+        dataset = WxDataset(
+            root=model.setting.root,
+            resolution=model.setting.resolution,
+            years=model.setting.years_test,
+            vars=model.setting.vars,
+            levels=model.setting.levels,
+            input_span=model.setting.input_span,
+            pred_shift=model.setting.pred_shift,
+            pred_span=model.setting.pred_span,
+            step=model.setting.step,
+        )
+
+        # Find the index of the specific datetime
+        datetime_index = np.where(dataset.time == np.datetime64(opt.datetime))[0][0]
+
+        # Get the input data for the specific datetime
+        inputs, _ = dataset[datetime_index]
+
+        # Convert inputs to torch tensors
+        inputs = {k: th.tensor(v, dtype=th.float32).unsqueeze(0) for k, v in inputs.items()}
+
+        # Perform inference
+        with th.no_grad():
+            results = model(**inputs)
+
+        # Save the output
+        if opt.output.endswith('.png'):
+            for var, data in results.items():
+                plot(var, open(opt.output, mode="wb"), data.squeeze().cpu().numpy())
+        elif opt.output.endswith('.nc'):
+            ds = xr.Dataset({var: (("time", "lat", "lon"), data.squeeze().cpu().numpy()) for var, data in results.items()})
+            ds.to_netcdf(opt.output)
+        else:
+            raise ValueError("Unsupported output format. Use either png or nc.")
+
+    except ImportError as e:
+        exc_info = sys.exc_info()
+        print(e)
+        print("failure when loading model")
+        import traceback
+
+        traceback.print_exception(*exc_info)
+        del exc_info
+        sys.exit(-1)
+
+
+def main_gan(context, opt):
+    try:
+        os.environ["CUDA_VISIBLE_DEVICES"] = opt.gpu
+        sys.path.insert(0, os.getcwd())
+        mdm = importlib.import_module(opt.module, package=None)
+        generator = mdm.generator
+
+        # Load the model checkpoint if provided
+        if opt.load:
+            checkpoint = th.load(opt.load)
+            generator.load_state_dict(checkpoint['state_dict'])
+
+        # Set the model to evaluation mode
+        generator.eval()
+
+        # Load the dataset
+        dataset = WxDataset(
+            root=generator.setting.root,
+            resolution=generator.setting.resolution,
+            years=generator.setting.years_test,
+            vars=generator.setting.vars,
+            levels=generator.setting.levels,
+            input_span=generator.setting.input_span,
+            pred_shift=generator.setting.pred_shift,
+            pred_span=generator.setting.pred_span,
+            step=generator.setting.step,
+        )
+
+        # Find the index of the specific datetime
+        datetime_index = np.where(dataset.time == np.datetime64(opt.datetime))[0][0]
+
+        # Get the input data for the specific datetime
+        inputs, _ = dataset[datetime_index]
+
+        # Convert inputs to torch tensors
+        inputs = {k: th.tensor(v, dtype=th.float32).unsqueeze(0) for k, v in inputs.items()}
+
+        # Perform GAN inference
+        results = []
+        with th.no_grad():
+            for _ in range(opt.samples):
+                noise = th.randn_like(inputs['data'][:, :1, :, :], dtype=th.float32)
+                inputs['noise'] = noise
+                result = generator(**inputs)
+                results.append(result['data'].cpu().numpy())
+
+        # Save the output
+        if opt.output.endswith('.png'):
+            for i, data in enumerate(results):
+                plot(f"sample_{i}", open(f"{opt.output}_{i}.png", mode="wb"), data.squeeze())
+        elif opt.output.endswith('.nc'):
+            ds = xr.Dataset({f"sample_{i}": (("time", "lat", "lon"), data.squeeze()) for i, data in enumerate(results)})
+            ds.to_netcdf(opt.output)
+        else:
+            raise ValueError("Unsupported output format. Use either png or nc.")
+
+    except ImportError as e:
+        exc_info = sys.exc_info()
+        print(e)
+        print("failure when loading model")
+        import traceback
+
+        traceback.print_exception(*exc_info)
+        del exc_info
+        sys.exit(-1)

--- a/wxbtool/wxb.py
+++ b/wxbtool/wxb.py
@@ -298,13 +298,7 @@ def inferg(parser, context, args):
     opt = parser.parse_args(args)
 
     inferg_main(context, opt)
-        "-G",
-        "--gan",
-        type=str,
-        default="false",
-        help="model is GAN or not, default is false",
-    )
-    
+
 
 @subcmd("download", help="download the latest hourly ERA5 data from ECMWF")
 def download(parser, context, args):

--- a/wxbtool/wxb.py
+++ b/wxbtool/wxb.py
@@ -3,6 +3,8 @@ from arghandler import ArgumentHandler, subcmd
 from wxbtool.data.dsserver import main as dsmain
 from wxbtool.nn.train import main as tnmain
 from wxbtool.nn.test import main as ttmain
+from wxbtool.nn.infer import main as infer_main
+from wxbtool.nn.infer import main_gan as inferg_main
 
 
 @subcmd
@@ -164,6 +166,120 @@ def test(parser, context, args):
     opt = parser.parse_args(args)
 
     ttmain(context, opt)
+
+
+@subcmd("infer", help="start inference")
+def infer(parser, context, args):
+    parser.add_argument("-g", "--gpu", type=str, default="0", help="index of gpu")
+    parser.add_argument(
+        "-c",
+        "--n_cpu",
+        type=int,
+        default=8,
+        help="number of cpu threads to use during batch generation",
+    )
+    parser.add_argument(
+        "-b", "--batch_size",
+        type=int,
+        default=64,
+        help="size of the batches"
+    )
+    parser.add_argument(
+        "-m",
+        "--module",
+        type=str,
+        default="wxbtool.zoo.unet.t850d3",
+        help="module of the metrological model to load",
+    )
+    parser.add_argument(
+        "-l",
+        "--load",
+        type=str,
+        default="",
+        help="dump file of the metrological model to load",
+    )
+    parser.add_argument(
+        "-d",
+        "--data",
+        type=str,
+        default="",
+        help="http url of the dataset server or binding unix socket (unix:/path/to/your.sock)",
+    )
+    parser.add_argument(
+        "-t", "--datetime",
+        type=str,
+        required=True,
+        help="specific datetime for inference in the format YYYY-MM-DDTHH:MM:SS",
+    )
+    parser.add_argument(
+        "-o", "--output",
+        type=str,
+        required=True,
+        help="output file format, either png or nc",
+    )
+    opt = parser.parse_args(args)
+
+    infer_main(context, opt)
+
+
+@subcmd("inferg", help="start GAN inference")
+def inferg(parser, context, args):
+    parser.add_argument("-g", "--gpu", type=str, default="0", help="index of gpu")
+    parser.add_argument(
+        "-c",
+        "--n_cpu",
+        type=int,
+        default=8,
+        help="number of cpu threads to use during batch generation",
+    )
+    parser.add_argument(
+        "-b", "--batch_size",
+        type=int,
+        default=64,
+        help="size of the batches"
+    )
+    parser.add_argument(
+        "-m",
+        "--module",
+        type=str,
+        default="wxbtool.zoo.unet.t850d3",
+        help="module of the metrological model to load",
+    )
+    parser.add_argument(
+        "-l",
+        "--load",
+        type=str,
+        default="",
+        help="dump file of the metrological model to load",
+    )
+    parser.add_argument(
+        "-d",
+        "--data",
+        type=str,
+        default="",
+        help="http url of the dataset server or binding unix socket (unix:/path/to/your.sock)",
+    )
+    parser.add_argument(
+        "-t", "--datetime",
+        type=str,
+        required=True,
+        help="specific datetime for inference in the format YYYY-MM-DDTHH:MM:SS",
+    )
+    parser.add_argument(
+        "-s", "--samples",
+        type=int,
+        required=True,
+        help="number of samples for GAN inference",
+    )
+    parser.add_argument(
+        "-o", "--output",
+        type=str,
+        required=True,
+        help="output file format, either png or nc",
+    )
+    opt = parser.parse_args(args)
+
+    inferg_main(context, opt)
 
 
 def main():


### PR DESCRIPTION
Add `infer` and `inferg` subcommands to `wxb` tool for inference on inputs with a specific datetime and output in png or nc format.

* **README.md**
  - Add usage examples for the `infer` and `inferg` subcommands.

* **wxbtool/wxb.py**
  - Add `infer` subcommand to perform inference on inputs with a specific datetime using the `-t` option and output in png or nc format using the `-o` option.
  - Add `inferg` subcommand to perform GAN inference on inputs with a specific datetime using the `-t` option, the number of samples using the `-s` option, and output in png or nc format using the `-o` option.

* **wxbtool/nn/infer.py**
  - Add `main` function to handle inference logic for the `infer` subcommand.
  - Add `main_gan` function to handle GAN inference logic for the `inferg` subcommand.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mountain/wxbtool/pull/7?shareId=367a261d-f1ac-4106-9c72-85235accd634).