### PR TITLE
Add wxb download subcommand to download latest hourly ERA5 data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "requests-unixsocket>=0.3.0",
     "flake8>=7.1.1",
     "pytest>=8.3.3",
+    "cdsapi>=0.7.4",
 ]
 
 [project.scripts]

--- a/wxbtool/data/download.py
+++ b/wxbtool/data/download.py
@@ -1,0 +1,88 @@
+import cdsapi
+import xarray as xr
+import numpy as np
+import os
+import shutil
+import datetime
+import logging
+
+def download_latest_hourly_era5_data(variables, start_date, end_date, output_folder):
+    c = cdsapi.Client()
+    for variable in variables:
+        variable_folder = os.path.join(output_folder, variable)
+        if not os.path.exists(variable_folder):
+            os.makedirs(variable_folder)
+
+        for date in (start_date + datetime.timedelta(n) for n in range((end_date - start_date).days + 1)):
+            year_folder = os.path.join(variable_folder, date.strftime("%Y"))
+            if not os.path.exists(year_folder):
+                os.makedirs(year_folder)
+
+            month_folder = os.path.join(year_folder, date.strftime("%m"))
+            if not os.path.exists(month_folder):
+                os.makedirs(month_folder)
+
+            filename = os.path.join(month_folder, date.strftime("%Y%m%d_%H") + ".nc")
+            if not os.path.exists(filename):
+                c.retrieve(
+                    "reanalysis-era5-single-levels",
+                    {
+                        "product_type": "reanalysis",
+                        "variable": variable,
+                        "year": date.strftime("%Y"),
+                        "month": date.strftime("%m"),
+                        "day": date.strftime("%d"),
+                        "time": date.strftime("%H:00"),
+                        "format": "netcdf",
+                    },
+                    filename,
+                )
+
+def organize_downloaded_data(output_folder):
+    for variable in os.listdir(output_folder):
+        variable_folder = os.path.join(output_folder, variable)
+        for year in os.listdir(variable_folder):
+            year_folder = os.path.join(variable_folder, year)
+            for month in os.listdir(year_folder):
+                month_folder = os.path.join(year_folder, month)
+                for filename in os.listdir(month_folder):
+                    file_path = os.path.join(month_folder, filename)
+                    file_date = datetime.datetime.strptime(filename, "%Y%m%d_%H.nc")
+                    new_filename = file_date.strftime("%Y%m%d_%H") + ".nc"
+                    new_file_path = os.path.join(month_folder, new_filename)
+                    if file_path != new_file_path:
+                        os.rename(file_path, new_file_path)
+
+def handle_coverage_option(coverage, output_folder, variables):
+    now = datetime.datetime.utcnow()
+    if coverage == "daily":
+        start_date = now - datetime.timedelta(days=1)
+    elif coverage == "weekly":
+        start_date = now - datetime.timedelta(weeks=1)
+    elif coverage == "monthly":
+        start_date = now - datetime.timedelta(weeks=4)
+    else:
+        start_date = now - datetime.timedelta(days=1)
+
+    download_latest_hourly_era5_data(variables, start_date, now, output_folder)
+    organize_downloaded_data(output_folder)
+
+def handle_retention_option(retention, output_folder, variables):
+    now = datetime.datetime.utcnow()
+    retention_period = {
+        "daily": datetime.timedelta(days=1),
+        "weekly": datetime.timedelta(weeks=1),
+        "monthly": datetime.timedelta(weeks=4),
+    }[retention]
+
+    for variable in variables:
+        variable_folder = os.path.join(output_folder, variable)
+        for year_folder in os.listdir(variable_folder):
+            year_folder_path = os.path.join(variable_folder, year_folder)
+            for month_folder in os.listdir(year_folder_path):
+                month_folder_path = os.path.join(year_folder_path, month_folder)
+                for filename in os.listdir(month_folder_path):
+                    file_path = os.path.join(month_folder_path, filename)
+                    file_date = datetime.datetime.strptime(filename, "%Y%m%d_%H.nc")
+                    if now - file_date > retention_period:
+                        os.remove(file_path)

--- a/wxbtool/wxb.py
+++ b/wxbtool/wxb.py
@@ -1,3 +1,11 @@
+import os
+import shutil
+import datetime
+import logging
+import cdsapi
+import xarray as xr
+import numpy as np
+
 from arghandler import ArgumentHandler, subcmd
 
 from wxbtool.data.dsserver import main as dsmain
@@ -137,33 +145,129 @@ def test(parser, context, args):
     parser.add_argument(
         "-m",
         "--module",
-        type=str,
+        type.str,
         default="wxbtool.zoo.unet.t850d3",
         help="module of the metrological model to load",
     )
     parser.add_argument(
         "-l",
         "--load",
-        type=str,
+        type.str,
         default="",
         help="dump file of the metrological model to load",
     )
     parser.add_argument(
         "-d",
         "--data",
-        type=str,
+        type.str,
         default="",
         help="http url of the dataset server or binding unix socket (unix:/path/to/your.sock)",
     )
     parser.add_argument(
-        "-G", "--gan", type=str, default="false", help="training GAN or not, default is false"
+        "-G", "--gan", type.str, default="false", help="training GAN or not, default is false"
     )
     parser.add_argument(
-        "-t", "--test", type=str, default="false", help="setting for test"
+        "-t", "--test", type.str, default="false", help="setting for test"
     )
     opt = parser.parse_args(args)
 
     ttmain(context, opt)
+
+
+@subcmd("download", help="download the latest hourly ERA5 data from ECMWF")
+def download(parser, context, args):
+    parser.add_argument(
+        "--coverage",
+        type=str,
+        choices=["daily", "weekly", "monthly"],
+        help="specify the period for which data coverage is required",
+    )
+    parser.add_argument(
+        "--retention",
+        type=str,
+        choices=["daily", "weekly", "monthly"],
+        help="specify the retention period for keeping the latest data",
+    )
+    opt = parser.parse_args(args)
+
+    download_data(opt.coverage, opt.retention)
+
+
+def download_data(coverage, retention):
+    c = cdsapi.Client()
+
+    # Define the variables to download
+    variables = [
+        "2m_temperature",
+        "total_precipitation",
+    ]
+
+    # Define the time range for the data
+    now = datetime.datetime.utcnow()
+    if coverage == "daily":
+        start_date = now - datetime.timedelta(days=1)
+    elif coverage == "weekly":
+        start_date = now - datetime.timedelta(weeks=1)
+    elif coverage == "monthly":
+        start_date = now - datetime.timedelta(weeks=4)
+    else:
+        start_date = now - datetime.timedelta(days=1)
+
+    # Create the .era5 folder if it doesn't exist
+    era5_folder = ".era5"
+    if not os.path.exists(era5_folder):
+        os.makedirs(era5_folder)
+
+    # Download the data
+    for variable in variables:
+        variable_folder = os.path.join(era5_folder, variable)
+        if not os.path.exists(variable_folder):
+            os.makedirs(variable_folder)
+
+        for date in (start_date + datetime.timedelta(n) for n in range((now - start_date).days + 1)):
+            year_folder = os.path.join(variable_folder, date.strftime("%Y"))
+            if not os.path.exists(year_folder):
+                os.makedirs(year_folder)
+
+            month_folder = os.path.join(year_folder, date.strftime("%m"))
+            if not os.path.exists(month_folder):
+                os.makedirs(month_folder)
+
+            filename = os.path.join(month_folder, date.strftime("%Y%m%d_%H") + ".nc")
+            if not os.path.exists(filename):
+                c.retrieve(
+                    "reanalysis-era5-single-levels",
+                    {
+                        "product_type": "reanalysis",
+                        "variable": variable,
+                        "year": date.strftime("%Y"),
+                        "month": date.strftime("%m"),
+                        "day": date.strftime("%d"),
+                        "time": date.strftime("%H:00"),
+                        "format": "netcdf",
+                    },
+                    filename,
+                )
+
+    # Handle retention
+    if retention:
+        retention_period = {
+            "daily": datetime.timedelta(days=1),
+            "weekly": datetime.timedelta(weeks=1),
+            "monthly": datetime.timedelta(weeks=4),
+        }[retention]
+
+        for variable in variables:
+            variable_folder = os.path.join(era5_folder, variable)
+            for year_folder in os.listdir(variable_folder):
+                year_folder_path = os.path.join(variable_folder, year_folder)
+                for month_folder in os.listdir(year_folder_path):
+                    month_folder_path = os.path.join(year_folder_path, month_folder)
+                    for filename in os.listdir(month_folder_path):
+                        file_path = os.path.join(month_folder_path, filename)
+                        file_date = datetime.datetime.strptime(filename, "%Y%m%d_%H.nc")
+                        if now - file_date > retention_period:
+                            os.remove(file_path)
 
 
 def main():

--- a/wxbtool/wxb.py
+++ b/wxbtool/wxb.py
@@ -145,29 +145,29 @@ def test(parser, context, args):
     parser.add_argument(
         "-m",
         "--module",
-        type.str,
+        type=str,
         default="wxbtool.zoo.unet.t850d3",
         help="module of the metrological model to load",
     )
     parser.add_argument(
         "-l",
         "--load",
-        type.str,
+        type=str,
         default="",
         help="dump file of the metrological model to load",
     )
     parser.add_argument(
         "-d",
         "--data",
-        type.str,
+        type=str,
         default="",
         help="http url of the dataset server or binding unix socket (unix:/path/to/your.sock)",
     )
     parser.add_argument(
-        "-G", "--gan", type.str, default="false", help="training GAN or not, default is false"
+        "-G", "--gan", type=str, default="false", help="training GAN or not, default is false"
     )
     parser.add_argument(
-        "-t", "--test", type.str, default="false", help="setting for test"
+        "-t", "--test", type=str, default="false", help="setting for test"
     )
     opt = parser.parse_args(args)
 


### PR DESCRIPTION
Add `wxb download` subcommand to download the latest hourly ERA5 data from ECMWF with `--coverage` and `--retention` options.

* **wxbtool/wxb.py**
  - Import necessary dependencies: `os`, `shutil`, `datetime`, `logging`, `cdsapi`, `xarray`, `numpy`.
  - Add `wxb download` subcommand with `--coverage` and `--retention` options.
  - Implement `download_data` function to handle data download and organization.
  - Implement logic to handle `--coverage` and `--retention` options.

* **wxbtool/data/download.py**
  - Import necessary dependencies: `cdsapi`, `xarray`, `numpy`, `os`, `shutil`, `datetime`, `logging`.
  - Implement `download_latest_hourly_era5_data` function to download data.
  - Implement `organize_downloaded_data` function to organize downloaded data.
  - Implement `handle_coverage_option` function to handle `--coverage` option.
  - Implement `handle_retention_option` function to handle `--retention` option.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mountain/wxbtool/pull/9?shareId=1f6f458a-b811-4a64-87c2-599089d25a24).